### PR TITLE
Ontology validator using describedBy and $ref URIs

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,10 +40,10 @@ FILE_VALIDATION = "ACTIVE"
 FILE_VALIDATION = os.path.expandvars(os.environ.get('FILE_VALIDATION', FILE_VALIDATION))
 
 
-FASTQ_VALIDATION_IMAGE = "quay.io/humancellatlas/fastq_utils:wrapping_error_messages"
+FASTQ_VALIDATION_IMAGE = "quay.io/humancellatlas/fastq_utils:master"
 FASTQ_VALIDATION_IMAGE = os.path.expandvars(os.environ.get('FASTQ_VALIDATION_IMAGE', FASTQ_VALIDATION_IMAGE))
 
-FASTQ_GZ_VALIDATION_IMAGE = "quay.io/humancellatlas/ingest-fastq-validator"
+FASTQ_GZ_VALIDATION_IMAGE = "quay.io/humancellatlas/fastq_utils:master"
 FASTQ_VALIDATION_IMAGE = os.path.expandvars(os.environ.get('FASTQ_VALIDATION_IMAGE', FASTQ_VALIDATION_IMAGE))
 
 

--- a/config.py
+++ b/config.py
@@ -40,7 +40,7 @@ FILE_VALIDATION = "ACTIVE"
 FILE_VALIDATION = os.path.expandvars(os.environ.get('FILE_VALIDATION', FILE_VALIDATION))
 
 
-FASTQ_VALIDATION_IMAGE = "quay.io/humancellatlas/ingest-fastq-validator"
+FASTQ_VALIDATION_IMAGE = "quay.io/humancellatlas/fastq_utils:wrapping_error_messages"
 FASTQ_VALIDATION_IMAGE = os.path.expandvars(os.environ.get('FASTQ_VALIDATION_IMAGE', FASTQ_VALIDATION_IMAGE))
 
 FASTQ_GZ_VALIDATION_IMAGE = "quay.io/humancellatlas/ingest-fastq-validator"

--- a/ontologyvalidator/ontologyvalidateutil.py
+++ b/ontologyvalidator/ontologyvalidateutil.py
@@ -100,13 +100,18 @@ class OntologyValidationUtil:
             else:
                 return lookup_response
 
-
+    '''
+    extracts the describedBy URL from the piece of metadata json provided 
+    '''
     def extract_schema_url_from_document(self, metadata_document):
         try:
             return metadata_document["describedBy"]
         except KeyError as e:
             raise MissingSchemaUrlException("Could not find schema url for this document")
 
+    '''
+    extracts the reference URL from the piece of metadata json provided 
+    '''
     def extract_reference_url_from_schema(self, metadata_schema):
         try:
             if "$ref" in metadata_schema:
@@ -116,6 +121,9 @@ class OntologyValidationUtil:
         except KeyError as e:
             raise MissingSchemaUrlException("Could not find schema url for this document")
 
+    '''
+    retrieves the schema json from the URL provided
+    '''
     def get_schema_from_url(self, schema_url):
         return requests.get(schema_url).json()
 

--- a/ontologyvalidator/ontologyvalidateutil.py
+++ b/ontologyvalidator/ontologyvalidateutil.py
@@ -114,10 +114,10 @@ class OntologyValidationUtil:
     '''
     def extract_reference_url_from_schema(self, metadata_schema):
         try:
-            if "$ref" in metadata_schema:
-                return metadata_schema["$ref"]
-            elif "items" in metadata_schema and "$ref" in metadata_schema["items"]:
-                return metadata_schema["items"]["$ref"]
+            if "items" in metadata_schema:
+                metadata_schema = metadata_schema["items"]
+
+            return metadata_schema["$ref"]
         except KeyError as e:
             raise MissingSchemaUrlException("Could not find schema url for this document")
 

--- a/ontologyvalidator/ontologyvalidator.py
+++ b/ontologyvalidator/ontologyvalidator.py
@@ -28,9 +28,14 @@ class OntologyValidator:
 
         for (ontology_term_field_path, ontology_term_id) in self.util.find_ontology_terms_in_document(metadata_document):
             try:
-                file_name = self.util.get_ontology_schema_file_name_from_ontology_field(ontology_term_field_path)
-                schema = self.util.retrieve_ontology_schema(self.schema_base_url, file_name)
-                lookup_query = self.util.generate_ols_query(schema, ontology_term_id)
+                # file_name = self.util.get_ontology_schema_file_name_from_ontology_field(ontology_term_field_path)
+                parent_schema_url = self.util.extract_schema_url_from_document(metadata_document)
+                parent_schema = self.util.get_schema_from_url(parent_schema_url)
+                ontology_schema_field = parent_schema["properties"][ontology_term_field_path.split(".")[0]]
+                # schema = self.util.retrieve_ontology_schema(self.schema_base_url, file_name)
+                ontology_schema_url = self.util.extract_reference_url_from_schema(ontology_schema_field)
+                ontology_schema = self.util.get_schema_from_url(ontology_schema_url)
+                lookup_query = self.util.generate_ols_query(ontology_schema, ontology_term_id)
                 lookup_response = self.util.lookup_ontology_term(lookup_query)
 
                 if lookup_response.json()["response"]["numFound"] == 0:

--- a/tests/test_files/metadata_documents/biomaterial_document.json
+++ b/tests/test_files/metadata_documents/biomaterial_document.json
@@ -1,9 +1,8 @@
 {
-  "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/donor_organism",
+  "describedBy": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/donor_organism",
   "schema_version": "5.0.0",
   "schema_type": "biomaterial",
   "biomaterial_core": {
-    "describedBy": "https://schema.humancellatlas.org/core/biomaterial/5.0.0/biomaterial_core",
     "biomaterial_id": "d1",
     "biomaterial_name": "donor1",
     "ncbi_taxon_id": [
@@ -13,15 +12,13 @@
   "is_living": true,
   "biological_sex": "male",
   "development_stage": {
-    "describedBy": "https://schema.humancellatlas.org/module/ontology/5.0.0/development_stage_ontology",
     "text": "adult",
-    "ontology": "EFO_0001272"
+    "ontology": "EFO:0001272"
   },
   "genus_species": [
     {
-      "describedBy": "https://schema.humancellatlas.org/module/ontology/5.0.0/species_ontology",
       "text": "Homo sapiens",
-      "ontology": "NCBITAXON_9606"
+      "ontology": "NCBITaxon:9606"
     }
   ]
 }

--- a/tests/test_files/schema/donor_organism.json
+++ b/tests/test_files/schema/donor_organism.json
@@ -1,156 +1,156 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "https://schema.humancellatlas.org/type/biomaterial/5.0.0/donor_organism",
-  "description": "Information about the organism from which a specimen was collected.",
-  "additionalProperties": false,
-  "required": [
-    "describedBy",
-    "schema_type",
-    "biomaterial_core",
-    "is_living",
-    "biological_sex"
-  ],
-  "title": "donor_organism",
-  "type": "object",
-  "properties": {
-    "describedBy":  {
-      "description": "The URL reference to the schema.",
-      "type": "string",
-      "pattern" : "https://schema.humancellatlas.org/type/biomaterial/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/donor_organism"
-    },
-    "schema_version": {
-      "description": "The version number of the schema in major.minor.patch format.",
-      "type": "string",
-      "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
-      "example": "4.6.1"
-    },
-    "schema_type": {
-      "description": "The type of the metadata schema entity.",
-      "type": "string",
-      "enum": [
-        "biomaterial"
-      ]
-    },
-    "biomaterial_core" : {
-      "description": "Core biomaterial-level information.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/core/biomaterial/5.0.0/biomaterial_core"
-    },
-    "human_specific": {
-      "description": "Fields specific to human (homo sapiens) organisms.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.0.0/homo_sapiens_specific"
-    },
-    "mus_musculus_specific": {
-      "description": "Fields specific to mouse (mus musculus) organisms.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.0.0/mus_musculus_specific"
-    },
-    "death": {
-      "description": "Information about conditions of death of an organism.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.0.0/death"
-    },
-    "medical_history": {
-      "description": "Information about the medical history of an organism.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.0.0/medical_history"
-    },
-    "genus_species": {
-      "description": "The scientific binomial name for the species of the biomaterial.",
-      "type" : "array",
-      "example": "Homo sapiens",
-      "items":{
-        "$ref": "https://schema.humancellatlas.org/module/ontology/5.0.0/species_ontology"
-      },
-      "user_friendly": "Genus species"
-    },
-    "organism_age": {
-      "description": "Age in age_units. Measured since birth.",
-      "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
-      "type": "string",
-      "user_friendly": "Organism age"
-    },
-    "organism_age_unit": {
-      "description": "The unit in which age is expressed. Must be one of hour, day, week, month, or year.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/ontology/5.0.0/time_unit_ontology",
-      "user_friendly": "Organism age unit",
-      "example": "year"
-    },
-    "development_stage": {
-      "description": "A classification of the developmental stage of the organism.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/ontology/5.0.0/development_stage_ontology",
-      "user_friendly": "Development stage"
-    },
-    "disease": {
-      "description": "Short description of disease status of the organism.",
-      "type": "array",
-      "items": {
-        "$ref": "https://schema.humancellatlas.org/module/ontology/5.0.0/disease_ontology"
-      },
-      "user_friendly": "Disease"
-    },
-    "familial_relationship": {
-      "description": "Information about other organisms related to this organism.",
-      "type": "array",
-      "items": {
-        "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.0.0/familial_relationship"
-      },
-      "user_friendly": "Familial relationship"
-    },
-    "gestational_age": {
-      "description": "Gestational age in gestational_age_units. Measured since fertilization.",
-      "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
-      "type": "string",
-      "user_friendly": "Gestational age"
-    },
-    "gestational_age_unit": {
-      "description": "The unit in which gestational age is expressed. Must be one of hour, day, week, month, or year.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/ontology/5.0.0/time_unit_ontology",
-      "user_friendly": "Gestational age unit"
-    },
-    "height": {
-      "description": "Height of organism in height units.",
-      "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
-      "type": "string",
-      "user_friendly": "Height"
-    },
-    "height_unit": {
-      "description": "The unit in which height is expressed. Must be a child term of https://www.ebi.ac.uk/ols/ontologies/uo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUO_0000001.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/ontology/5.0.0/length_unit_ontology",
-      "user_friendly": "Height unit"
-    },
-    "is_living": {
-      "description": "Yes if organism is living at time of biomaterial collection. No otherwise.",
-      "type": "boolean",
-      "user_friendly": "Is living?"
-    },
-    "biological_sex": {
-      "description": "The biological sex of the organism. Should be one of male, female, mixed, or unknown.",
-      "type": "string",
-      "enum": [
-        "female",
-        "male",
-        "mixed",
-        "unknown"
-      ],
-      "user_friendly": "Biological sex"
-    },
-    "weight": {
-      "description": "Weight of organism in kilograms.",
-      "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
-      "type": "string",
-      "user_friendly": "Weight"
-    },
-    "weight_unit": {
-      "description": "The unit in which weight is expressed. Must be a child term of https://www.ebi.ac.uk/ols/ontologies/uo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUO_0000002.",
-      "type": "object",
-      "$ref": "https://schema.humancellatlas.org/module/ontology/5.0.0/mass_unit_ontology",
-      "user_friendly": "Weight unit"
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://schema.humancellatlas.org/type/biomaterial/5.1.0/donor_organism",
+    "description": "Information about the organism from which a specimen was collected.",
+    "additionalProperties": false,
+    "required": [
+        "describedBy",
+        "schema_type",
+        "biomaterial_core",
+        "is_living",
+        "biological_sex"
+    ],
+    "title": "donor_organism",
+    "type": "object",
+    "properties": {
+        "describedBy":  {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "https://schema.humancellatlas.org/type/biomaterial/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/donor_organism"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "schema_type": {
+            "description": "The type of the metadata schema entity.",
+            "type": "string",
+            "enum": [
+                "biomaterial"
+            ]
+        },
+        "biomaterial_core" : {
+            "description": "Core biomaterial-level information.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/core/biomaterial/5.1.0/biomaterial_core"
+        },
+        "human_specific": {
+            "description": "Fields specific to human (homo sapiens) organisms.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.1.0/homo_sapiens_specific"
+        },
+        "mus_musculus_specific": {
+            "description": "Fields specific to mouse (mus musculus) organisms.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.1.0/mus_musculus_specific"
+        },
+        "death": {
+            "description": "Information about conditions of death of an organism.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.1.0/death"
+        },
+        "medical_history": {
+            "description": "Information about the medical history of an organism.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.1.0/medical_history"
+        },
+        "genus_species": {
+            "description": "The scientific binomial name for the species of the biomaterial.",
+            "type" : "array",
+            "example": "Homo sapiens",
+            "items":{
+                "$ref": "https://schema.humancellatlas.org/module/ontology/5.1.0/species_ontology"
+            },
+            "user_friendly": "Genus species"
+        },
+        "organism_age": {
+            "description": "Age in age_units. Measured since birth.",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
+            "type": "string",
+            "user_friendly": "Organism age"
+        },
+        "organism_age_unit": {
+            "description": "The unit in which age is expressed. Must be one of hour, day, week, month, or year.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/ontology/5.1.0/time_unit_ontology",
+            "user_friendly": "Organism age unit",
+            "example": "year"
+        },
+        "development_stage": {
+            "description": "A classification of the developmental stage of the organism.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/ontology/5.1.0/development_stage_ontology",
+            "user_friendly": "Development stage"
+        },
+        "disease": {
+            "description": "Short description of disease status of the organism.",
+            "type": "array",
+            "items": {
+                "$ref": "https://schema.humancellatlas.org/module/ontology/5.1.0/disease_ontology"
+	        },
+            "user_friendly": "Disease"
+        },
+        "familial_relationship": {
+            "description": "Information about other organisms related to this organism.",
+            "type": "array",
+            "items": {
+                "$ref": "https://schema.humancellatlas.org/module/biomaterial/5.1.0/familial_relationship"
+                },
+            "user_friendly": "Familial relationship"
+        },
+        "gestational_age": {
+            "description": "Gestational age in gestational_age_units. Measured since fertilization.",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
+            "type": "string",
+            "user_friendly": "Gestational age"
+        },
+        "gestational_age_unit": {
+            "description": "The unit in which gestational age is expressed. Must be one of hour, day, week, month, or year.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/ontology/5.1.0/time_unit_ontology",
+            "user_friendly": "Gestational age unit"
+        },
+        "height": {
+            "description": "Height of organism in height units.",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
+            "type": "string",
+            "user_friendly": "Height"
+        },
+        "height_unit": {
+            "description": "The unit in which height is expressed. Must be a child term of https://www.ebi.ac.uk/ols/ontologies/uo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUO_0000001.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/ontology/5.1.0/length_unit_ontology",
+            "user_friendly": "Height unit"
+        },
+        "is_living": {
+            "description": "Yes if organism is living at time of biomaterial collection. No otherwise.",
+            "type": "boolean",
+            "user_friendly": "Is living?"
+        },
+        "biological_sex": {
+            "description": "The biological sex of the organism. Should be one of male, female, mixed, or unknown.",
+            "type": "string",
+            "enum": [
+                "female",
+                "male",
+                "mixed",
+                "unknown"
+            ],
+            "user_friendly": "Biological sex"
+        },
+        "weight": {
+            "description": "Weight of organism in kilograms.",
+            "pattern": "^[0-9]+\\.?[0-9]*-?[0-9]*\\.?[0-9]*$",
+            "type": "string",
+            "user_friendly": "Weight"
+        },
+        "weight_unit": {
+            "description": "The unit in which weight is expressed. Must be a child term of https://www.ebi.ac.uk/ols/ontologies/uo/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUO_0000002.",
+            "type": "object",
+            "$ref": "https://schema.humancellatlas.org/module/ontology/5.1.0/mass_unit_ontology",
+            "user_friendly": "Weight unit"
+        }
     }
-  }
 }

--- a/tests/test_files/schema/test_body_part_ontology_schema.json
+++ b/tests/test_files/schema/test_body_part_ontology_schema.json
@@ -1,27 +1,39 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "additionalProperties": false,
-  "description": "A term that may be associated with an anatomy-related ontology term",
-  "properties": {
-    "text": {
-      "description": "The text for the term as the user provides it.",
-      "type": "string"
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://schema.humancellatlas.org/module/ontology/5.1.0/organ_part_ontology",
+    "description": "A term that may be associated with an anatomy-related ontology term",
+    "additionalProperties": false,
+    "required": [
+        "text"
+    ],
+    "title": "organ_part_ontology",
+    "properties": {
+        "describedBy":  {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern" : "https://schema.humancellatlas.org/module/ontology/[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/organ_part_ontology"
+        },
+        "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+        },
+        "text": {
+            "description": "The text for the term as the user provides it.",
+            "type": "string"
+        },
+        "ontology": {
+            "description": "A term for a specific part of an organ from the ontology [UBERON](https://www.ebi.ac.uk/ols/ontologies/uberon).",
+            "type": "string",
+            "graph_restriction":  {
+                "ontologies" : ["obo:uberon", "obo:efo"],
+                "classes": ["UBERON:0000465"],
+                "relations": ["rdfs:subClassOf"],
+                "direct": false,
+                "include_self": true
+            }
+        }
     },
-    "ontology": {
-      "description": "An optional ontology reference in format where prefix_ indicates which ontology",
-      "type": "string",
-      "graph_restriction":  {
-        "ontologies" : ["obo:uberon", "obo:efo"],
-        "classes": ["UBERON:0000465"],
-        "relations": ["rdfs:subClassOf"],
-        "direct": false,
-        "include_self": true
-      }
-    }
-  },
-  "required": [
-    "text"
-  ],
-  "title": "body_part_ontology",
-  "type": "object"
+    "type": "object"
 }

--- a/tests/test_ontology_validation.py
+++ b/tests/test_ontology_validation.py
@@ -15,7 +15,7 @@ class TestOntologyValidation(unittest.TestCase):
         with open(BASE_PATH + "/test_files/metadata_documents/biomaterial_document.json") as document_file:
             document = json.load(document_file)
             fields_found = util.find_ontology_terms_in_document(document)
-            assert(len(fields_found) == 2 and (fields_found[0][0] == "development_stage.ontology" or fields_found[0][0] == "genus_species.ontology"))
+            assert(len(fields_found) == 2 and (fields_found[0][0] == "development_stage.ontology" or fields_found[0][0] == "genus_species.0.ontology"))
 
     def test_generate_ontology_schema_file_name_from_ontology_field(self):
         util = ontology_validate_util.OntologyValidationUtil()

--- a/tests/test_ontology_validation.py
+++ b/tests/test_ontology_validation.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import ontologyvalidator.ontologyvalidateutil as ontology_validate_util
 import ontologyvalidator.ontologyvalidator as validator
+from common.missingschemaurlexception import MissingSchemaUrlException
 import json
 from unittest import mock
 
@@ -77,3 +78,25 @@ class TestOntologyValidation(unittest.TestCase):
             ontology_validation_report = ontology_validator.validate(json.load(document_file))
 
             assert ontology_validation_report.validation_state == "VALID" and len(ontology_validation_report.error_reports) == 0
+
+    def test_extract_schema_url_from_metadata_no_schema_url(self):
+        with open(BASE_PATH + "/test_files/metadata_documents/biomaterial_document.json") as sample_document_file:
+            metadata_document = json.load(sample_document_file)
+            del metadata_document["describedBy"]
+            util = ontology_validate_util.OntologyValidationUtil()
+            try:
+                schema_url = util.extract_schema_url_from_document(metadata_document)
+                assert False
+            except MissingSchemaUrlException as e:
+                assert True
+
+    def test_extract_reference_url_from_schema_no_reference_url(self):
+        with open(BASE_PATH + "/test_files/schema/donor_organism.json") as sample_schema_file:
+            metadata_schema = json.load(sample_schema_file)
+            del metadata_schema["properties"]["biomaterial_core"]["$ref"]
+            util = ontology_validate_util.OntologyValidationUtil()
+            try:
+                schema_url = util.extract_reference_url_from_schema(metadata_schema["properties"]["biomaterial_core"])
+                assert False
+            except MissingSchemaUrlException as e:
+                    assert True


### PR DESCRIPTION
The ontology validator is now able to read URIs out of metadata docs and schemas from schema.humancellatlas.org..

These changes do NOT include migration to using the HCA OLS instance (http://ontology.dev.data.humancellatlas.org)!